### PR TITLE
Fix byte-complete warnings

### DIFF
--- a/mol-tree-meta-mode.el
+++ b/mol-tree-meta-mode.el
@@ -6,6 +6,8 @@
 
 ;;; Code:
 
+(require 'mol-tree-mode)
+
 (defvar mol-tree-meta-font-lock-keywords
   `(
     ("^\\(pack\\|include\\|require\\|deploy\\)\\b" . (1 font-lock-builtin-face))

--- a/mol-tree-view-mode.el
+++ b/mol-tree-view-mode.el
@@ -6,6 +6,8 @@
 
 ;;; Code:
 
+(require 'mol-tree-mode)
+
 (defcustom mol-tree-view-block-literal-search-lines 100
   "*Maximum number of lines to search for start of block literals."
   :type 'integer


### PR DESCRIPTION
```
mol-tree-meta-mode.el:15:7:Warning: reference to free variable
    ‘mol-tree-fl-symbols-re’
mol-tree-meta-mode.el:16:7:Warning: reference to free variable
    ‘mol-tree-fl-array-type-re’
mol-tree-meta-mode.el:18:7:Warning: reference to free variable
    ‘mol-tree-fl-error-space-re’
mol-tree-meta-mode.el:19:7:Warning: reference to free variable
    ‘mol-tree-fl-error-tabs-re’
mol-tree-meta-mode.el:20:7:Warning: reference to free variable
    ‘mol-tree-fl-comment-re’
mol-tree-meta-mode.el:22:7:Warning: reference to free variable
    ‘mol-tree-fl-raw-re’

In end of data:
mol-tree-meta-mode.el:45:1:Warning: the function ‘mol-tree-mode’ is not known
    to be defined.

mol-tree-view-mode.el:77:7:Warning: reference to free variable
    ‘mol-tree-fl-builtin-values-re’
mol-tree-view-mode.el:87:7:Warning: reference to free variable
    ‘mol-tree-fl-symbols-re’
mol-tree-view-mode.el:88:7:Warning: reference to free variable
    ‘mol-tree-fl-array-type-re’
mol-tree-view-mode.el:91:7:Warning: reference to free variable
    ‘mol-tree-fl-error-space-re’
mol-tree-view-mode.el:92:7:Warning: reference to free variable
    ‘mol-tree-fl-error-tabs-re’
mol-tree-view-mode.el:93:7:Warning: reference to free variable
    ‘mol-tree-fl-comment-re’
mol-tree-view-mode.el:96:7:Warning: reference to free variable
    ‘mol-tree-fl-raw-re’

In end of data:
mol-tree-view-mode.el:119:1:Warning: the function ‘mol-tree-mode’ is not known
    to be defined.
```